### PR TITLE
print: Reject enroll images that can't be matched

### DIFF
--- a/libfprint/fpi-image-device.c
+++ b/libfprint/fpi-image-device.c
@@ -277,7 +277,7 @@ fpi_image_device_minutiae_detected (GObject *source_object, GAsyncResult *res, g
     {
       print = fp_print_new (device);
       fpi_print_set_type (print, FPI_PRINT_NBIS);
-      if (!fpi_print_add_from_image (print, image, &error))
+      if (!fpi_print_add_from_image (print, image, priv->bz3_threshold, &error))
         {
           g_clear_object (&print);
 

--- a/libfprint/fpi-print.h
+++ b/libfprint/fpi-print.h
@@ -40,6 +40,7 @@ void     fpi_print_set_device_stored (FpPrint *print,
 
 gboolean fpi_print_add_from_image (FpPrint *print,
                                    FpImage *image,
+                                   gint     bz3_threshold,
                                    GError **error);
 
 FpiMatchResult fpi_print_bz3_match (FpPrint * template,


### PR DESCRIPTION
If the score of a print matching itself is too low to match, then reject it. It can never match and it is therefore completely useless.

Also change this into a non-fatal error, the user is free to retry the enroll step in the hope that more minutiae is found (e.g. longer swipe).