### PR TITLE
tests: Adjust timeouts to avoid CI failures

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -57,7 +57,7 @@ test:
   script:
     - meson --werror -Ddrivers=all -Db_coverage=true . _build
     - ninja -C _build
-    - meson test -C _build --verbose --no-stdsplit --timeout-multiplier 3
+    - meson test -C _build --verbose --no-stdsplit
     - ninja -C _build coverage
     - cat _build/meson-logs/coverage.txt
   artifacts:

--- a/tests/meson.build
+++ b/tests/meson.build
@@ -30,6 +30,7 @@ if get_option('introspection')
         unittest_inspector = find_program('unittest_inspector.py')
         base_args = files('virtual-image.py')
         suite = []
+        timeout = 30
 
         r = run_command(unittest_inspector, files('virtual-image.py'))
         unit_tests = r.stdout().strip().split('\n')
@@ -38,6 +39,7 @@ if get_option('introspection')
             suite += 'virtual-image'
         else
             unit_tests = ['virtual-image']
+            timeout = 120
         endif
 
         foreach ut: unit_tests
@@ -53,6 +55,7 @@ if get_option('introspection')
                 suite: ut_suite,
                 depends: libfprint_typelib,
                 env: envs,
+                timeout: timeout,
             )
         endforeach
     else


### PR DESCRIPTION
The virtual-image test is quite CPU intensive and can take a long time in the CI setup. Adjust the timeouts so that it runs reliably.